### PR TITLE
Load weights correctly when continuing training from checkpoint

### DIFF
--- a/models/model_factory.py
+++ b/models/model_factory.py
@@ -49,6 +49,12 @@ def model_generator(args, add_bg_mask=True):
             saved_state_dict = model_zoo.load_url(restore_from)
         else:
             saved_state_dict = torch.load(restore_from)
+        optimizer_state_dict = None
+        if 'optimizer_state_dict' in saved_state_dict:
+            optimizer_state_dict = saved_state_dict['optimizer_state_dict']
+        if 'model_state_dict' in saved_state_dict:
+            # Trainer.save_model saves dict
+            saved_state_dict = saved_state_dict['model_state_dict']
 
         saved_state_dict = dict([(k.replace('module.', ''), v) for k, v in saved_state_dict.items()])
         # only copy the params that exist in current model (caffe-like)
@@ -58,4 +64,4 @@ def model_generator(args, add_bg_mask=True):
                 new_params[name].copy_(saved_state_dict[name])
         model.load_state_dict(new_params)
 
-    return model
+    return model, optimizer_state_dict

--- a/trainer_ours.py
+++ b/trainer_ours.py
@@ -57,7 +57,7 @@ class Trainer(nn.Module):
         print("Nondet")
 
         # create network
-        model = model_generator(args, add_bg_mask=False)
+        model, optimizer_state_dict = model_generator(args, add_bg_mask=False)
         model.train()
         model.cuda(args.gpu)
         self.model = model
@@ -94,7 +94,11 @@ class Trainer(nn.Module):
         # Initialize optimizers.
         self.optimizer_seg = optim.SGD(self.model.optim_parameters(args),
                                        lr=args.learning_rate, momentum=args.momentum, weight_decay=args.weight_decay)
-        self.optimizer_seg.zero_grad()
+        if optimizer_state_dict is not None:
+            # resume training from checkpoint
+            self.optimizer_seg.load_state_dict(optimizer_state_dict)
+        else:
+            self.optimizer_seg.zero_grad()
 
         # visualizor
         self.viz = Visualizer(args)


### PR DESCRIPTION
Hi

Thanks for providing the cool repo! After retraining your model successfully I wanted to do some experiments with the fully trained network and started using the `restore_from` flag in the configs with either my own trained network or the provided weights saved at `checkpoints/CUB/model_60000.pth`.

After trying out a bit I realized the model was not at all as good as I expected, performing way worse than at the end of the training. After some digging around I found the following:

When a checkpoint is loaded using `restore_from` all weight checkpoint loading fails silently, the following is the reason:

```python3
def save_model(self, path, iter):
    torch.save({
        'iter': iter,
        'model_state_dict': self.model.state_dict(),
        'optimizer_state_dict': self.optimizer_seg.state_dict(),
        }, path)
```

saves a dict with three keys, however `def model_generator` does not consider this. All checks in this [if statement](https://github.com/subhc/unsup-parts/blob/3e30b372136517ef010e974503389a3ae6833bb2/models/model_factory.py#L57) therefore fail and the trained weights are not loaded.

I add a hotfix for this, as well as extracting the `optimizer_state_dict` when available and initializing the `optimizer` as such when continuing from a checkpoint.