### PR TITLE
Main Result changing bugfix

### DIFF
--- a/evaluation/CUB eval.ipynb
+++ b/evaluation/CUB eval.ipynb
@@ -310,7 +310,7 @@
     "        ari = adjusted_rand_score(nmi_gts, nmi_preds_w_bg) * 100\n",
     "    else:\n",
     "        nmi = normalized_mutual_info_score(nmi_gts, nmi_preds) * 100\n",
-    "        ari = adjusted_rand_score(nmi_gts, nmi_preds_w_bg) * 100\n",
+    "        ari = adjusted_rand_score(nmi_gts, nmi_preds) * 100\n",
     "    return nmi, ari"
    ]
   },


### PR DESCRIPTION
```   
    print(np.unique(nmi_gts), np.unique(nmi_preds), np.unique(nmi_preds_w_bg))
    if is_full:
        nmi = normalized_mutual_info_score(nmi_gts, nmi_preds_w_bg) * 100
        ari = adjusted_rand_score(nmi_gts, nmi_preds_w_bg) * 100
    else:
        nmi = normalized_mutual_info_score(nmi_gts, nmi_preds) * 100
        ari = adjusted_rand_score(nmi_gts, nmi_preds_w_bg) * 100
    return nmi, ari
```

`ari = adjusted_rand_score(nmi_gts, nmi_preds_w_bg) * 100`
-->
`ari = adjusted_rand_score(nmi_gts, nmi_preds) * 100`



in the evaluation notebook the foreground ari score is calculated with nmi predictions with background. FG-ARI on CUB increases from 21.0 to 21.65 when fixed. As this is a main result I think it is important to change this in the code and paper